### PR TITLE
Add Vue.js Google Maps route search page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# map_test
+# Map Test
+
+This project demonstrates a simple Vue.js page that displays Google Maps and allows route searches between a starting point and destination.
+
+## Getting Started
+
+1. Replace `YOUR_API_KEY` in `index.html` with your Google Maps JavaScript API key.
+2. Open `index.html` in your browser or host the repository with GitHub Pages.
+
+## Usage
+
+Enter a departure point and destination, then click **検索** to see the route displayed on the map.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <title>Google Maps Route Search</title>
+  <style>
+    #map { height: 400px; width: 100%; }
+  </style>
+</head>
+<body>
+  <div id="app">
+    <input v-model="origin" placeholder="出発地" />
+    <input v-model="destination" placeholder="目的地" />
+    <button @click="calculateRoute">検索</button>
+    <div id="map"></div>
+  </div>
+
+  <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+  <script>
+    const app = Vue.createApp({
+      data() {
+        return {
+          map: null,
+          directionsService: null,
+          directionsRenderer: null,
+          origin: '',
+          destination: ''
+        };
+      },
+      methods: {
+        initMap() {
+          this.map = new google.maps.Map(document.getElementById('map'), {
+            center: { lat: 35.681236, lng: 139.767125 },
+            zoom: 14
+          });
+          this.directionsService = new google.maps.DirectionsService();
+          this.directionsRenderer = new google.maps.DirectionsRenderer();
+          this.directionsRenderer.setMap(this.map);
+        },
+        calculateRoute() {
+          if (!this.origin || !this.destination) return;
+          this.directionsService.route(
+            {
+              origin: this.origin,
+              destination: this.destination,
+              travelMode: google.maps.TravelMode.DRIVING
+            },
+            (result, status) => {
+              if (status === 'OK' && result) {
+                this.directionsRenderer.setDirections(result);
+              } else {
+                alert('ルートを取得できませんでした: ' + status);
+              }
+            }
+          );
+        }
+      }
+    });
+
+    const vm = app.mount('#app');
+    window.initMap = () => {
+      vm.initMap();
+    };
+  </script>
+  <script async defer src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&callback=initMap"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` with Vue 3 and Google Maps integration for route searching
- document usage and API key instructions in README

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/map_test/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c017e2ce0c8331aba5dc064180b9f0