### PR TITLE
Embed static Google Map without API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,7 @@
 # Map Test
 
-This project demonstrates a simple Vue.js page that displays Google Maps and allows route searches between a starting point and destination.
+Simple page that displays a Google Map without requiring an API key.
 
 ## Getting Started
 
-1. Replace `YOUR_API_KEY` in `index.html` with your Google Maps JavaScript API key.
-2. Open `index.html` in your browser or host the repository with GitHub Pages.
-
-## Usage
-
-Enter a departure point and destination, optionally choose a date and time, then click **検索** to see the route displayed on the map.
+Open `index.html` in your browser to see a map centered on Tokyo Station.

--- a/index.html
+++ b/index.html
@@ -2,75 +2,20 @@
 <html lang="ja">
 <head>
   <meta charset="utf-8" />
-  <title>Google Maps Route Search</title>
+  <title>Google Map Display</title>
   <style>
-    #map { height: 400px; width: 100%; }
+    #map {
+      width: 100%;
+      height: 400px;
+      border: 0;
+    }
   </style>
 </head>
 <body>
-  <div id="app">
-    <input v-model="origin" placeholder="出発地" />
-    <input v-model="destination" placeholder="目的地" />
-    <input type="date" v-model="departureDate" />
-    <input type="time" v-model="departureTime" />
-    <button @click="calculateRoute">検索</button>
-    <div id="map"></div>
-  </div>
-
-  <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
-  <script>
-    const app = Vue.createApp({
-      data() {
-        return {
-          map: null,
-          directionsService: null,
-          directionsRenderer: null,
-          origin: '',
-          destination: '',
-          departureDate: '',
-          departureTime: ''
-        };
-      },
-      methods: {
-        initMap() {
-          this.map = new google.maps.Map(document.getElementById('map'), {
-            center: { lat: 35.681236, lng: 139.767125 },
-            zoom: 14
-          });
-          this.directionsService = new google.maps.DirectionsService();
-          this.directionsRenderer = new google.maps.DirectionsRenderer();
-          this.directionsRenderer.setMap(this.map);
-        },
-        calculateRoute() {
-          if (!this.origin || !this.destination) return;
-          const request = {
-            origin: this.origin,
-            destination: this.destination,
-            travelMode: google.maps.TravelMode.DRIVING
-          };
-
-          if (this.departureDate && this.departureTime) {
-            request.drivingOptions = {
-              departureTime: new Date(`${this.departureDate}T${this.departureTime}`)
-            };
-          }
-
-          this.directionsService.route(request, (result, status) => {
-            if (status === 'OK' && result) {
-              this.directionsRenderer.setDirections(result);
-            } else {
-              alert('ルートを取得できませんでした: ' + status);
-            }
-          });
-        }
-      }
-    });
-
-    const vm = app.mount('#app');
-    window.initMap = () => {
-      vm.initMap();
-    };
-  </script>
-  <script defer src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&callback=initMap"></script>
+  <iframe
+    id="map"
+    src="https://maps.google.com/maps?q=35.681236,139.767125&z=14&output=embed"
+    allowfullscreen>
+  </iframe>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace Vue-based route search page with a simple embedded Google Map iframe
- Remove API key requirement and simplify README instructions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a1dd812483319ccdc88aff2f9ca0