### PR TITLE
Add page title and full-screen map layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,16 +2,33 @@
 <html lang="ja">
 <head>
   <meta charset="utf-8" />
-  <title>Google Map Display</title>
+  <title>map_test</title>
   <style>
+    html,
+    body {
+      height: 100%;
+      margin: 0;
+    }
+
+    body {
+      display: flex;
+      flex-direction: column;
+    }
+
+    h1 {
+      margin: 0;
+      padding: 16px;
+      text-align: center;
+    }
+
     #map {
-      width: 100%;
-      height: 400px;
+      flex: 1;
       border: 0;
     }
   </style>
 </head>
 <body>
+  <h1>map_test</h1>
   <iframe
     id="map"
     src="https://maps.google.com/maps?q=35.681236,139.767125&z=14&output=embed"


### PR DESCRIPTION
## Summary
- add `map_test` page title header and document title
- use flex layout so the embedded Google Map fills the viewport

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d2fd7d488331b459b8c503b147fe