### PR TITLE
Plot Kariya bus GTFS data on Google Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Map Test
 
-Simple page that displays a Google Map without requiring an API key.
+Displays a Google Map and plots stops from a GTFS dataset.
 
 ## Getting Started
 
-Open `index.html` in your browser to see a map centered on Tokyo Station.
+1. Obtain a Google Maps JavaScript API key and replace `YOUR_API_KEY` in `index.html`.
+2. Download the Kariya City bus GTFS zip from [GTFS Data.jp](https://gtfs-data.jp/search?pref=%E6%84%9B%E7%9F%A5%E7%9C%8C) and save it as `kariya_gtfs.zip` in this directory.
+3. Open `index.html` in your browser to view bus stops plotted on the map.

--- a/index.html
+++ b/index.html
@@ -23,16 +23,15 @@
 
     #map {
       flex: 1;
-      border: 0;
     }
   </style>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js" integrity="sha512-pXAFeoDyAJ6Digw1k3D6Z0SqnX+0Gooy2cuglRez2oJ6TP2PzefDs2fzGEylh4G6dkprdOCi/hTyBC0bYKT1Fg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js" integrity="sha512-7QFRsCG2l9VmOAXoJ1i8LojRxurx8WcN6i/K3PaY5E9O+V1YQUAECEV4VpWw2X2gYdEx+kt1/3uzjlGz5x1JPQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="main.js"></script>
 </head>
 <body>
   <h1>map_test</h1>
-  <iframe
-    id="map"
-    src="https://maps.google.com/maps?q=35.681236,139.767125&z=14&output=embed"
-    allowfullscreen>
-  </iframe>
+  <div id="map"></div>
+  <script async defer src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&callback=initMap"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,33 @@
+async function initMap() {
+  const map = new google.maps.Map(document.getElementById('map'), {
+    center: { lat: 34.9896, lng: 137.0025 },
+    zoom: 13,
+  });
+
+  const GTFS_ZIP_URL = './kariya_gtfs.zip'; // Replace with actual URL or local path
+  try {
+    const response = await fetch(GTFS_ZIP_URL);
+    const blob = await response.blob();
+    const zip = await JSZip.loadAsync(blob);
+    const stopsTxt = await zip.file('stops.txt').async('string');
+    Papa.parse(stopsTxt, {
+      header: true,
+      skipEmptyLines: true,
+      complete: function (results) {
+        results.data.forEach((stop) => {
+          if (stop.stop_lat && stop.stop_lon) {
+            new google.maps.Marker({
+              position: { lat: parseFloat(stop.stop_lat), lng: parseFloat(stop.stop_lon) },
+              map,
+              title: stop.stop_name,
+            });
+          }
+        });
+      },
+    });
+  } catch (err) {
+    console.error('Failed to load GTFS data:', err);
+  }
+}
+
+window.initMap = initMap;


### PR DESCRIPTION
## Summary
- Switch index to use Google Maps API and load GTFS stops
- Add script that fetches a GTFS zip and plots stop markers
- Update docs with instructions for API key and GTFS download

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68c2d7b86e908331a51cb732ea034f51