### PR TITLE
Switch to Leaflet for map display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Map Test
 
-Displays a Google Map and plots stops from a GTFS dataset.
+Displays a Leaflet map and plots stops from a GTFS dataset.
 
 ## Getting Started
 
-1. Obtain a Google Maps JavaScript API key and replace `YOUR_API_KEY` in `index.html`.
-2. Download the Kariya City bus GTFS zip from [GTFS Data.jp](https://gtfs-data.jp/search?pref=%E6%84%9B%E7%9F%A5%E7%9C%8C) and save it as `kariya_gtfs.zip` in this directory.
-3. Open `index.html` in your browser to view bus stops plotted on the map.
+1. Download the Kariya City bus GTFS zip from [GTFS Data.jp](https://gtfs-data.jp/search?pref=%E6%84%9B%E7%9F%A5%E7%9C%8C) and save it as `kariya_gtfs.zip` in this directory.
+2. Open `index.html` in your browser to view bus stops plotted on the map.

--- a/index.html
+++ b/index.html
@@ -25,13 +25,17 @@
       flex: 1;
     }
   </style>
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+  />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js" integrity="sha512-pXAFeoDyAJ6Digw1k3D6Z0SqnX+0Gooy2cuglRez2oJ6TP2PzefDs2fzGEylh4G6dkprdOCi/hTyBC0bYKT1Fg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js" integrity="sha512-7QFRsCG2l9VmOAXoJ1i8LojRxurx8WcN6i/K3PaY5E9O+V1YQUAECEV4VpWw2X2gYdEx+kt1/3uzjlGz5x1JPQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="main.js"></script>
 </head>
 <body>
   <h1>map_test</h1>
   <div id="map"></div>
-  <script async defer src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&callback=initMap"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,8 +1,10 @@
 async function initMap() {
-  const map = new google.maps.Map(document.getElementById('map'), {
-    center: { lat: 34.9896, lng: 137.0025 },
-    zoom: 13,
-  });
+  const map = L.map('map').setView([34.9896, 137.0025], 13);
+
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution:
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+  }).addTo(map);
 
   const GTFS_ZIP_URL = './kariya_gtfs.zip'; // Replace with actual URL or local path
   try {
@@ -16,11 +18,10 @@ async function initMap() {
       complete: function (results) {
         results.data.forEach((stop) => {
           if (stop.stop_lat && stop.stop_lon) {
-            new google.maps.Marker({
-              position: { lat: parseFloat(stop.stop_lat), lng: parseFloat(stop.stop_lon) },
-              map,
-              title: stop.stop_name,
-            });
+            L.marker(
+              [parseFloat(stop.stop_lat), parseFloat(stop.stop_lon)],
+              { title: stop.stop_name }
+            ).addTo(map);
           }
         });
       },
@@ -30,4 +31,4 @@ async function initMap() {
   }
 }
 
-window.initMap = initMap;
+document.addEventListener('DOMContentLoaded', initMap);


### PR DESCRIPTION
## Summary
- replace Google Maps API with Leaflet and OpenStreetMap tiles
- plot GTFS stops using Leaflet markers
- update documentation to reflect new map setup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e14999b48331b272207810307209