### PR TITLE
Fetch GTFS data from remote API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ Displays a Leaflet map and plots stops from a GTFS dataset.
 
 ## Getting Started
 
-1. Download the Kariya City bus GTFS zip from [GTFS Data.jp](https://gtfs-data.jp/search?pref=%E6%84%9B%E7%9F%A5%E7%9C%8C) and save it as `kariya_gtfs.zip` in this directory.
-2. Open `index.html` in your browser to view bus stops plotted on the map.
+1. Open `index.html` in your browser. The application automatically fetches the
+   latest Kariya City community bus GTFS data from [GTFS Data.jp](https://gtfs-data.jp)
+   and displays the stops on the map.

--- a/main.js
+++ b/main.js
@@ -6,7 +6,10 @@ async function initMap() {
       '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
   }).addTo(map);
 
-  const GTFS_ZIP_URL = './kariya_gtfs.zip'; // Replace with actual URL or local path
+  // Latest GTFS data for Kariya City community bus is available via the API.
+  // Fetch the zip directly from the remote server instead of requiring a local file.
+  const GTFS_ZIP_URL =
+    'https://api.gtfs-data.jp/v2/organizations/kariyacity/feeds/communitybus/files/feed.zip?rid=next';
   try {
     const response = await fetch(GTFS_ZIP_URL);
     const blob = await response.blob();


### PR DESCRIPTION
## Summary
- Retrieve Kariya City community bus GTFS data directly from GTFS Data.jp API
- Update documentation to reflect automatic GTFS fetching

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e61bc4648331987290cdfecc9dd7