### PR TITLE
Decode GTFS stops using Shift_JIS on client

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,7 +14,9 @@ async function initMap() {
     const response = await fetch(GTFS_ZIP_URL);
     const blob = await response.blob();
     const zip = await JSZip.loadAsync(blob);
-    const stopsTxt = await zip.file('stops.txt').async('string');
+    // stops.txt is encoded in Shift_JIS, so decode it on the client
+    const stopsBuffer = await zip.file('stops.txt').async('arraybuffer');
+    const stopsTxt = new TextDecoder('shift_jis').decode(stopsBuffer);
     Papa.parse(stopsTxt, {
       header: true,
       skipEmptyLines: true,


### PR DESCRIPTION
## Summary
- Decode `stops.txt` from the GTFS feed with `TextDecoder('shift_jis')` on the client
- Parse the decoded text directly in the browser to plot stops

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2eb17ce308331b68009e614753ce5