### PR TITLE
Use Google Maps instead of Leaflet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Map Test
 
-Displays a Leaflet map and plots stops from a GTFS dataset.
+Displays a Google Map and plots stops from a GTFS dataset. Replace `YOUR_API_KEY` in `index.html` with your Google Maps JavaScript API key.
 
 ## Getting Started
 

--- a/index.html
+++ b/index.html
@@ -25,14 +25,14 @@
       flex: 1;
     }
   </style>
-  <link
-    rel="stylesheet"
-    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-  />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js" integrity="sha512-pXAFeoDyAJ6Digw1k3D6Z0SqnX+0Gooy2cuglRez2oJ6TP2PzefDs2fzGEylh4G6dkprdOCi/hTyBC0bYKT1Fg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js" integrity="sha512-7QFRsCG2l9VmOAXoJ1i8LojRxurx8WcN6i/K3PaY5E9O+V1YQUAECEV4VpWw2X2gYdEx+kt1/3uzjlGz5x1JPQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="main.js"></script>
+  <script
+    src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&callback=initMap"
+    async
+    defer
+  ></script>
 </head>
 <body>
   <h1>map_test</h1>

--- a/main.js
+++ b/main.js
@@ -1,10 +1,8 @@
 async function initMap() {
-  const map = L.map('map').setView([34.9896, 137.0025], 13);
-
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution:
-      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-  }).addTo(map);
+  const map = new google.maps.Map(document.getElementById('map'), {
+    center: { lat: 34.9896, lng: 137.0025 },
+    zoom: 13,
+  });
 
   // Latest GTFS data for Kariya City community bus is available via the API.
   // Fetch the zip directly from the remote server instead of requiring a local file.
@@ -23,10 +21,14 @@ async function initMap() {
       complete: function (results) {
         results.data.forEach((stop) => {
           if (stop.stop_lat && stop.stop_lon) {
-            L.marker(
-              [parseFloat(stop.stop_lat), parseFloat(stop.stop_lon)],
-              { title: stop.stop_name }
-            ).addTo(map);
+            new google.maps.Marker({
+              position: {
+                lat: parseFloat(stop.stop_lat),
+                lng: parseFloat(stop.stop_lon),
+              },
+              map,
+              title: stop.stop_name,
+            });
           }
         });
       },
@@ -36,4 +38,4 @@ async function initMap() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', initMap);
+window.initMap = initMap;


### PR DESCRIPTION
## Summary
- replace Leaflet with Google Maps JavaScript API
- display GTFS stops as Google Maps markers
- document the need for a Google Maps API key

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c40fb01d1c8331933603723b53d6c0