### PR TITLE
Use Leaflet to display map without Google API key

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,14 +25,11 @@
       flex: 1;
     }
   </style>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="" />
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js" integrity="sha512-pXAFeoDyAJ6Digw1k3D6Z0SqnX+0Gooy2cuglRez2oJ6TP2PzefDs2fzGEylh4G6dkprdOCi/hTyBC0bYKT1Fg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js" integrity="sha512-7QFRsCG2l9VmOAXoJ1i8LojRxurx8WcN6i/K3PaY5E9O+V1YQUAECEV4VpWw2X2gYdEx+kt1/3uzjlGz5x1JPQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="main.js"></script>
-  <script
-    src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&callback=initMap"
-    async
-    defer
-  ></script>
+  <script src="main.js" defer></script>
 </head>
 <body>
   <h1>map_test</h1>

--- a/main.js
+++ b/main.js
@@ -1,18 +1,16 @@
 async function initMap() {
-  const map = new google.maps.Map(document.getElementById('map'), {
-    center: { lat: 34.9896, lng: 137.0025 },
-    zoom: 13,
-  });
+  const map = L.map('map').setView([34.9896, 137.0025], 13);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; OpenStreetMap contributors',
+    maxZoom: 19,
+  }).addTo(map);
 
-  // Latest GTFS data for Kariya City community bus is available via the API.
-  // Fetch the zip directly from the remote server instead of requiring a local file.
   const GTFS_ZIP_URL =
     'https://api.gtfs-data.jp/v2/organizations/kariyacity/feeds/communitybus/files/feed.zip?rid=next';
   try {
     const response = await fetch(GTFS_ZIP_URL);
     const blob = await response.blob();
     const zip = await JSZip.loadAsync(blob);
-    // stops.txt is encoded in Shift_JIS, so decode it on the client
     const stopsBuffer = await zip.file('stops.txt').async('arraybuffer');
     const stopsTxt = new TextDecoder('shift_jis').decode(stopsBuffer);
     Papa.parse(stopsTxt, {
@@ -21,14 +19,9 @@ async function initMap() {
       complete: function (results) {
         results.data.forEach((stop) => {
           if (stop.stop_lat && stop.stop_lon) {
-            new google.maps.Marker({
-              position: {
-                lat: parseFloat(stop.stop_lat),
-                lng: parseFloat(stop.stop_lon),
-              },
-              map,
-              title: stop.stop_name,
-            });
+            L.marker([parseFloat(stop.stop_lat), parseFloat(stop.stop_lon)])
+              .addTo(map)
+              .bindPopup(stop.stop_name);
           }
         });
       },
@@ -38,4 +31,5 @@ async function initMap() {
   }
 }
 
-window.initMap = initMap;
+document.addEventListener('DOMContentLoaded', initMap);
+


### PR DESCRIPTION
## Summary
- Replace Google Maps script with Leaflet and OpenStreetMap tiles
- Update map initialization to Leaflet and render bus stop markers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c41577b5788331b70bb71202028373