### PR TITLE
Connect bus stops with polylines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Map Test
 
-Displays a Google Map and plots stops from a GTFS dataset. Replace `YOUR_API_KEY` in `index.html` with your Google Maps JavaScript API key.
+Displays an interactive map and plots stops from a GTFS dataset. The stops are
+also connected in sequence based on the timetable data to visualize the bus
+routes.
 
 ## Getting Started
 

--- a/main.js
+++ b/main.js
@@ -13,18 +13,56 @@ async function initMap() {
     const zip = await JSZip.loadAsync(blob);
     const stopsBuffer = await zip.file('stops.txt').async('arraybuffer');
     const stopsTxt = new TextDecoder('shift_jis').decode(stopsBuffer);
-    Papa.parse(stopsTxt, {
-      header: true,
-      skipEmptyLines: true,
-      complete: function (results) {
-        results.data.forEach((stop) => {
-          if (stop.stop_lat && stop.stop_lon) {
-            L.marker([parseFloat(stop.stop_lat), parseFloat(stop.stop_lon)])
-              .addTo(map)
-              .bindPopup(stop.stop_name);
-          }
-        });
-      },
+    const stopMap = new Map();
+
+    await new Promise((resolve) => {
+      Papa.parse(stopsTxt, {
+        header: true,
+        skipEmptyLines: true,
+        complete: function (results) {
+          results.data.forEach((stop) => {
+            if (stop.stop_lat && stop.stop_lon) {
+              const lat = parseFloat(stop.stop_lat);
+              const lon = parseFloat(stop.stop_lon);
+              L.marker([lat, lon]).addTo(map).bindPopup(stop.stop_name);
+              stopMap.set(stop.stop_id, [lat, lon]);
+            }
+          });
+          resolve();
+        },
+      });
+    });
+
+    const stopTimesBuffer = await zip.file('stop_times.txt').async('arraybuffer');
+    const stopTimesTxt = new TextDecoder('shift_jis').decode(stopTimesBuffer);
+    await new Promise((resolve) => {
+      Papa.parse(stopTimesTxt, {
+        header: true,
+        skipEmptyLines: true,
+        complete: function (results) {
+          const trips = {};
+          results.data.forEach((st) => {
+            const trip = trips[st.trip_id] || [];
+            trip.push(st);
+            trips[st.trip_id] = trip;
+          });
+
+          Object.values(trips).forEach((times) => {
+            times.sort(
+              (a, b) => parseInt(a.stop_sequence, 10) - parseInt(b.stop_sequence, 10)
+            );
+            const latlngs = times
+              .map((t) => stopMap.get(t.stop_id))
+              .filter(Boolean);
+            if (latlngs.length > 1) {
+              L.polyline(latlngs, { color: 'blue', weight: 2, opacity: 0.5 }).addTo(
+                map
+              );
+            }
+          });
+          resolve();
+        },
+      });
     });
   } catch (err) {
     console.error('Failed to load GTFS data:', err);


### PR DESCRIPTION
## Summary
- store stop coordinates and markers in a map
- parse stop_times to draw polylines connecting sequential stops
- document route visualization in README

## Testing
- `node --check main.js`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5073653308331bbaba5f033da853b