### PR TITLE
Increase bus stop marker and name size

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,10 +21,13 @@
       text-align: center;
     }
 
-    #map {
-      flex: 1;
-    }
-  </style>
+      #map {
+        flex: 1;
+      }
+      .leaflet-popup-content {
+        font-size: 18px;
+      }
+    </style>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="" />
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js" integrity="sha512-pXAFeoDyAJ6Digw1k3D6Z0SqnX+0Gooy2cuglRez2oJ6TP2PzefDs2fzGEylh4G6dkprdOCi/hTyBC0bYKT1Fg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/main.js
+++ b/main.js
@@ -5,8 +5,18 @@ async function initMap() {
     maxZoom: 19,
   }).addTo(map);
 
+  const busIcon = L.icon({
+    iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+    shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+    iconSize: [50, 82],
+    iconAnchor: [25, 82],
+    popupAnchor: [1, -76],
+    shadowSize: [82, 82],
+    shadowAnchor: [25, 82],
+  });
+
   const GTFS_ZIP_URL =
-    'https://api.gtfs-data.jp/v2/organizations/kariyacity/feeds/communitybus/files/feed.zip?rid=next';
+      'https://api.gtfs-data.jp/v2/organizations/kariyacity/feeds/communitybus/files/feed.zip?rid=next';
   try {
     const response = await fetch(GTFS_ZIP_URL);
     const blob = await response.blob();
@@ -22,12 +32,14 @@ async function initMap() {
         complete: function (results) {
           results.data.forEach((stop) => {
             if (stop.stop_lat && stop.stop_lon) {
-              const lat = parseFloat(stop.stop_lat);
-              const lon = parseFloat(stop.stop_lon);
-              L.marker([lat, lon]).addTo(map).bindPopup(stop.stop_name);
-              stopMap.set(stop.stop_id, [lat, lon]);
-            }
-          });
+                const lat = parseFloat(stop.stop_lat);
+                const lon = parseFloat(stop.stop_lon);
+                L.marker([lat, lon], { icon: busIcon })
+                  .addTo(map)
+                  .bindPopup(stop.stop_name);
+                stopMap.set(stop.stop_id, [lat, lon]);
+              }
+            });
           resolve();
         },
       });


### PR DESCRIPTION
## Summary
- make bus stop marker icon larger
- enlarge popup text for stop names

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c509b1d28483319b7e48f394b0b083